### PR TITLE
Specify utf-8 file format for management/daemon.py

### DIFF
--- a/management/auth.py
+++ b/management/auth.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import base64, os, os.path, hmac
 
 from flask import make_response

--- a/management/backup.py
+++ b/management/backup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# -*- coding: utf-8 -*-
 
 # This script performs a backup of all user data:
 # 1) System services are stopped.

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -25,7 +25,7 @@ except OSError:
 
 # for generating CSRs we need a list of country codes
 csr_country_codes = []
-with open(os.path.join(os.path.dirname(me), "csr_country_codes.tsv")) as f:
+with open(os.path.join(os.path.dirname(me), "csr_country_codes.tsv"), encoding='utf-8') as f:
     for line in f:
         if line.strip() == "" or line.startswith("#"): continue
         code, name = line.strip().split("\t")[0:2]

--- a/management/daemon.py
+++ b/management/daemon.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# -*- coding: utf-8 -*-
 
 import os, os.path, re, json, time
 import subprocess
@@ -25,7 +26,7 @@ except OSError:
 
 # for generating CSRs we need a list of country codes
 csr_country_codes = []
-with open(os.path.join(os.path.dirname(me), "csr_country_codes.tsv"), encoding='utf-8') as f:
+with open(os.path.join(os.path.dirname(me), "csr_country_codes.tsv")) as f:
     for line in f:
         if line.strip() == "" or line.startswith("#"): continue
         code, name = line.strip().split("\t")[0:2]

--- a/management/daily_tasks.sh
+++ b/management/daily_tasks.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- coding: utf-8 -*-
 # This script is run daily (at 3am each night).
 
 # Set character encoding flags to ensure that any non-ASCII

--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# -*- coding: utf-8 -*-
 
 # Creates DNS zone files for all of the domains of all of the mail users
 # and mail aliases and restarts nsd.

--- a/management/email_administrator.py
+++ b/management/email_administrator.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# -*- coding: utf-8 -*-
 
 # Reads in STDIN. If the stream is not empty, mail it to the system administrator.
 

--- a/management/mail_log.py
+++ b/management/mail_log.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# -*- coding: utf-8 -*-
 
 import os.path
 import re

--- a/management/mailconfig.py
+++ b/management/mailconfig.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# -*- coding: utf-8 -*-
 
 import subprocess, shutil, os, re
 import utils

--- a/management/ssl_certificates.py
+++ b/management/ssl_certificates.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# -*- coding: utf-8 -*-
 # Utilities for installing and selecting SSL certificates.
 
 import os, os.path, re, shutil

--- a/management/status_checks.py
+++ b/management/status_checks.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# -*- coding: utf-8 -*-
 #
 # Checks that the upstream DNS has been set correctly and that
 # TLS certificates have been signed, etc., and if not tells the user

--- a/management/utils.py
+++ b/management/utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os.path
 
 

--- a/management/web_update.py
+++ b/management/web_update.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Creates an nginx configuration file so we serve HTTP/HTTPS on all
 # domains for which a mail account has been set up.
 ########################################################################

--- a/tests/fail2ban.py
+++ b/tests/fail2ban.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Test that a box's fail2ban setting are working
 # correctly by attempting a bunch of failed logins.
 #

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 #
 # Tests the DNS configuration of a Mail-in-a-Box.
 #

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 # Tests sending and receiving mail by sending a test message to yourself.
 
 import sys, imaplib, smtplib, uuid, time

--- a/tests/test_smtp_server.py
+++ b/tests/test_smtp_server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 import smtplib, sys
 
 if len(sys.argv) < 3:
@@ -16,4 +17,3 @@ server = smtplib.SMTP(host, 25)
 server.set_debuglevel(1)
 server.sendmail(fromaddr, [toaddr], msg)
 server.quit()
-

--- a/tests/tls.py
+++ b/tests/tls.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# -*- coding: utf-8 -*-
 
 # Runs SSLyze on the TLS endpoints of a box and outputs
 # the results so we can inspect the settings and compare


### PR DESCRIPTION
After googling around a bit it seems the errors I've experienced relate to the python library reading some invalid characters - manually specifying the encoding of the file in the daemon.py alleviates the issue - I'm not sure what specifically about running it in a service caused it to break.